### PR TITLE
Use Bitso fork of sqlcheck

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,8 @@
 FROM ubuntu:18.04
 
+ARG SQLCHECK_VERSION=1.2.1
+ARG SQLCHECK_PACKAGE=sqlcheck_${SQLCHECK_VERSION}_amd64.deb
+
 LABEL com.github.actions.name="SQLCheck Action"
 LABEL com.github.actions.description="GitHub Action for sqlcheck CLI"
 LABEL com.github.actions.icon="code"
@@ -10,8 +13,8 @@ LABEL repository="https://github.com/yokawasa/action-sqlcheck"
 # latest sqlcheck: https://github.com/jarulraj/sqlcheck/releases
 RUN apt-get update && \
   apt-get install -y --no-install-recommends ca-certificates curl jq && \
-  curl -L -O https://github.com/jarulraj/sqlcheck/releases/download/v1.2/sqlcheck-x86_64.deb && \
-  dpkg -i sqlcheck-x86_64.deb && \
+  curl -L -O https://github.com/bitsoex/sqlcheck/releases/download/${SQLCHECK_VERSION}/${SQLCHECK_PACKAGE} && \
+  dpkg -i ${SQLCHECK_PACKAGE} && \
   rm -rf /var/lib/apt/lists/*
 COPY entrypoint.sh /entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh"]


### PR DESCRIPTION
There's a [PR open][1] to fix an [issue][2] in `sqlcheck` that causes it to break (actually hang
indefinitely) on inputs with very long lines (4096 chars or longer).

It _appears_ that `sqlcheck` is no longer being maintained, so we've forked it and released a new
version [`1.2.1` release][3] containing the fix, which we can then use in our GitHub Actions
workflows.

[1]: https://github.com/jarulraj/sqlcheck/pull/38
[2]: https://github.com/jarulraj/sqlcheck/issues/32
[3]: https://github.com/bitsoex/sqlcheck/releases/tag/1.2.1
